### PR TITLE
timeouts: Use timeout ID for updating timeouts

### DIFF
--- a/adapters/memtimeoutstore/memtimeoutstore.go
+++ b/adapters/memtimeoutstore/memtimeoutstore.go
@@ -12,7 +12,8 @@ import (
 
 func New(opts ...Option) *Store {
 	s := &Store{
-		clock: clock.RealClock{},
+		clock:              clock.RealClock{},
+		timeoutIdIncrement: 1,
 	}
 
 	for _, opt := range opts {
@@ -74,24 +75,12 @@ func (s *Store) Create(ctx context.Context, workflowName, foreignID, runID strin
 	return nil
 }
 
-func (s *Store) Complete(ctx context.Context, workflowName, foreignID, runID string, status int) error {
+func (s *Store) Complete(ctx context.Context, id int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	for i, timeout := range s.timeouts {
-		if timeout.WorkflowName != workflowName {
-			continue
-		}
-
-		if timeout.ForeignID != foreignID {
-			continue
-		}
-
-		if timeout.RunID != runID {
-			continue
-		}
-
-		if timeout.Status != status {
+		if timeout.ID != id {
 			continue
 		}
 
@@ -102,25 +91,13 @@ func (s *Store) Complete(ctx context.Context, workflowName, foreignID, runID str
 	return nil
 }
 
-func (s *Store) Cancel(ctx context.Context, workflowName, foreignID, runID string, status int) error {
+func (s *Store) Cancel(ctx context.Context, id int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	var index int
 	for i, timeout := range s.timeouts {
-		if timeout.WorkflowName != workflowName {
-			continue
-		}
-
-		if timeout.ForeignID != foreignID {
-			continue
-		}
-
-		if timeout.RunID != runID {
-			continue
-		}
-
-		if timeout.Status != status {
+		if timeout.ID != id {
 			continue
 		}
 

--- a/adapters/sqltimeout/sqltimeout.go
+++ b/adapters/sqltimeout/sqltimeout.go
@@ -55,28 +55,22 @@ func (s *Store) Create(ctx context.Context, workflowName, foreignID, runID strin
 	return nil
 }
 
-func (s *Store) Complete(ctx context.Context, workflowName, foreignID, runID string, status int) error {
-	_, err := s.writer.ExecContext(ctx, "update "+s.timeoutTableName+" set completed=true where workflow_name=? and foreign_id=? and run_id=? and status=?", workflowName, foreignID, runID, status)
+func (s *Store) Complete(ctx context.Context, id int64) error {
+	_, err := s.writer.ExecContext(ctx, "update "+s.timeoutTableName+" set completed=true where id=?", id)
 	if err != nil {
 		return errors.Wrap(err, "failed to complete timeout", j.MKV{
-			"workflowName": workflowName,
-			"foreignID":    foreignID,
-			"runID":        runID,
-			"status":       status,
+			"id": id,
 		})
 	}
 
 	return nil
 }
 
-func (s *Store) Cancel(ctx context.Context, workflowName, foreignID, runID string, status int) error {
-	_, err := s.writer.ExecContext(ctx, "delete from "+s.timeoutTableName+" where workflow_name=? and foreign_id=? and run_id=? and status=?", workflowName, foreignID, runID, status)
+func (s *Store) Cancel(ctx context.Context, id int64) error {
+	_, err := s.writer.ExecContext(ctx, "delete from "+s.timeoutTableName+" where id=?", id)
 	if err != nil {
 		return errors.Wrap(err, "failed to cancel / delete timeout", j.MKV{
-			"workflowName": workflowName,
-			"foreignID":    foreignID,
-			"runID":        runID,
-			"status":       status,
+			"id": id,
 		})
 	}
 

--- a/adapters/testing/timeoutstore.go
+++ b/adapters/testing/timeoutstore.go
@@ -65,7 +65,7 @@ func testCancelTimeout(t *testing.T, store workflow.TimeoutStore) {
 	require.WithinDuration(t, time.Now().Add(-time.Hour), timeout[2].ExpireAt, time.Second)
 	require.WithinDuration(t, time.Now(), timeout[2].CreatedAt, time.Second)
 
-	err = store.Cancel(ctx, "example", "andrew", "2", int(statusStarted))
+	err = store.Cancel(ctx, 2)
 	jtest.RequireNil(t, err)
 
 	timeout, err = store.ListValid(ctx, "example", int(statusStarted), time.Now())
@@ -131,7 +131,7 @@ func testCompleteTimeout(t *testing.T, store workflow.TimeoutStore) {
 	require.WithinDuration(t, time.Now().Add(-time.Hour), timeout[2].ExpireAt, time.Second)
 	require.WithinDuration(t, time.Now(), timeout[2].CreatedAt, time.Second)
 
-	err = store.Complete(ctx, "example", "andrew", "2", int(statusStarted))
+	err = store.Complete(ctx, 2)
 	jtest.RequireNil(t, err)
 
 	timeout, err = store.ListValid(ctx, "example", int(statusStarted), time.Now())

--- a/store.go
+++ b/store.go
@@ -28,8 +28,8 @@ type EventEmitter func(id int64) error
 
 type TimeoutStore interface {
 	Create(ctx context.Context, workflowName, foreignID, runID string, status int, expireAt time.Time) error
-	Complete(ctx context.Context, workflowName, foreignID, runID string, status int) error
-	Cancel(ctx context.Context, workflowName, foreignID, runID string, status int) error
+	Complete(ctx context.Context, id int64) error
+	Cancel(ctx context.Context, id int64) error
 	List(ctx context.Context, workflowName string) ([]Timeout, error)
 	ListValid(ctx context.Context, workflowName string, status int, now time.Time) ([]Timeout, error)
 }


### PR DESCRIPTION
This updates timeout store to use ID's over descriptive details that can match more than one timeout at any given time. This became a bug when used in a infinite  state cycle with the memtimeoutstore. The SQLTimeout store was unaffected.